### PR TITLE
do not call update_alternates if package.importdir != package.srcdir

### DIFF
--- a/lib/autobuild/import/git.rb
+++ b/lib/autobuild/import/git.rb
@@ -508,7 +508,11 @@ module Autobuild
 
         def update(package,only_local = false)
             validate_importdir(package)
-            update_alternates(package)
+            # This is really really a hack to workaround how broken the
+            # importdir thing is
+            if package.importdir == package.srcdir
+                update_alternates(package)
+            end
             Dir.chdir(package.importdir) do
                 #Checking if we should only merge our repro to remotes/HEAD without updateing from the remote side...
                 if !only_local


### PR DESCRIPTION
importdir != srcdir really says that the current package is not the
one being imported, and that the alternates list cannot be generated,
so skip the update.

This fixes a bunch of warnings when using importdir with cache, where
the alternates would basically be modified for each sub-package.
