### PR TITLE
fixed version compare for git importer and added test case

### DIFF
--- a/lib/autobuild/import/git.rb
+++ b/lib/autobuild/import/git.rb
@@ -50,7 +50,8 @@ module Autobuild
         # Helper method to compare two (partial) versions represented as array
         # of integers
         #
-        # @return [Integer]
+        # @return [Integer] -1 if actual is greater than required, 
+        #   0 if equal, and 1 if actual is smaller than required
         def self.compare_versions(actual, required)
             if actual.size > required.size
                 return -compare_versions(required, actual)
@@ -71,7 +72,7 @@ module Autobuild
         # @return [Boolean] true if the git version is at least the requested
         #   one, and false otherwise
         def self.at_least_version(*version)
-            compare_versions(self.version, version) >= 0
+            compare_versions(self.version, version) <= 0
         end
 
         # Creates an importer which tracks the given repository

--- a/test/test_import_git.rb
+++ b/test/test_import_git.rb
@@ -12,6 +12,7 @@ describe Autobuild::Git do
         end
         it "should return 1 if the required version is greater" do
             assert_equal(1, Autobuild::Git.compare_versions([2, 0, 1], [2, 1, 0]))
+            assert_equal(1, Autobuild::Git.compare_versions([1, 9, 1], [2, 1, 0]))
         end
         it "should fill missing version parts with zeros" do
             assert_equal(-1, Autobuild::Git.compare_versions([2, 1], [2, 0, 1]))
@@ -20,6 +21,16 @@ describe Autobuild::Git do
             assert_equal(0, Autobuild::Git.compare_versions([2, 1, 0], [2, 1]))
             assert_equal(1, Autobuild::Git.compare_versions([2, 1], [2, 1, 1]))
             assert_equal(1, Autobuild::Git.compare_versions([2, 1, 1], [2, 2]))
+        end
+    end
+    describe "at_least_version" do
+        Autobuild::Git.stub :version, [1,9,1] do
+            it "should be true if required version is smaller" do
+                assert_equal( true, Autobuild::Git.at_least_version( 1,8,1 ) ) 
+            end
+            it "should be false if required version is greater" do
+                assert_equal( false, Autobuild::Git.at_least_version( 2,0,1 ) )
+            end
         end
     end
 end


### PR DESCRIPTION
the :at_least_version method had a sign error, and would return
the inverse of what would be expected.