### PR TITLE
detection of msys2 environment on windows

### DIFF
--- a/lib/autobuild/environment.rb
+++ b/lib/autobuild/environment.rb
@@ -19,11 +19,16 @@ module Autobuild
 
     @freebsd = RbConfig::CONFIG["host_os"].include?('freebsd') 
     def self.freebsd?
-	@freebsd
+        @freebsd
     end
 
     def self.bsd?
-	@freebsd || @macos #can be extended to some other OSes liek NetBSD
+        @freebsd || @macos #can be extended to some other OSes liek NetBSD
+    end
+
+    @msys =  RbConfig::CONFIG["host_os"] =~%r!(msys)!
+    def self.msys?
+        @msys
     end
 
     SYSTEM_ENV = Hash.new


### PR DESCRIPTION
"msys2" (https://msys2.github.io/) is a build environment for mingw on windows that includes a package manager (based on cygwin and mingw)