### PR TITLE
Detection of msys2 environment on Windows

### DIFF
--- a/lib/autobuild/environment.rb
+++ b/lib/autobuild/environment.rb
@@ -22,6 +22,11 @@ module Autobuild
         @freebsd || @macos #can be extended to some other OSes liek NetBSD
     end
 
+    @msys =  RbConfig::CONFIG["host_os"] =~%r!(msys)!
+    def self.msys?
+        @msys
+    end
+
     SHELL_VAR_EXPANSION =
         if windows? then "%%%s%%"
         else "$%s"


### PR DESCRIPTION
Rebased PR to autoproj 2.0 branch

(https://github.com/rock-core/autobuild/pull/25#issuecomment-141117371)

Now properly rebased and names.