### PR TITLE
Fix rebuild cxx11

### DIFF
--- a/lib/autobuild/package.rb
+++ b/lib/autobuild/package.rb
@@ -584,6 +584,41 @@ module Autobuild
             end
             super
         end
+
+        # For forward compatibility with autobuild 1.11+
+        #
+        # It simply calls the corresponding method on {Autobuild}
+        def env_add(name, *values)
+            Autobuild.env_add(name, *values)
+        end
+
+        # For forward compatibility with autobuild 1.11+
+        #
+        # It simply calls the corresponding method on {Autobuild}
+        def env_add_path(name, *values)
+            Autobuild.env_add_path(name, *values)
+        end
+
+        # For forward compatibility with autobuild 1.11+
+        #
+        # It simply calls the corresponding method on {Autobuild}
+        def env_set(name, *values)
+            Autobuild.env_add_path(name, *values)
+        end
+
+        # For forward compatibility with autobuild 1.11+
+        #
+        # It simply calls the corresponding method on {Autobuild}
+        def env_add_prefix(newprefix, includes = nil)
+            Autobuild.update_environment(newprefix, includes)
+        end
+
+        # For forward compatibility with autobuild 1.11+
+        #
+        # It returns ENV as the environment is global on autobuild 1.10
+        def resolved_env(_ignored = nil)
+            ENV.dup
+        end
     end
 
     def self.package_set(spec)

--- a/lib/autobuild/packages/cmake.rb
+++ b/lib/autobuild/packages/cmake.rb
@@ -329,7 +329,7 @@ module Autobuild
                     end
 
                     value = value.to_s
-                    old_value = cache_line.split("=")[1].chomp if cache_line
+                    old_value = cache_line.partition("=").last.chomp if cache_line
                     if !old_value || !equivalent_option_value?(old_value, value)
                         if Autobuild.debug
                             message "%s: option '#{name}' changed value: '#{old_value}' => '#{value}'"

--- a/lib/autobuild/version.rb
+++ b/lib/autobuild/version.rb
@@ -1,5 +1,5 @@
 module Autobuild
-    VERSION = "1.9.3" unless defined? Autobuild::VERSION
+    VERSION = "1.9.4" unless defined? Autobuild::VERSION
 end
 
 


### PR DESCRIPTION
Hey,
Adding -std=c++11 triggered a bug that the package was
rebuild every time. This commit fixes it.
Greetings
   Janosch