### PR TITLE
fix wrong rebuild if cmake value contains '='

### DIFF
--- a/lib/autobuild/packages/cmake.rb
+++ b/lib/autobuild/packages/cmake.rb
@@ -336,7 +336,7 @@ module Autobuild
                     end
 
                     value = value.to_s
-                    old_value = cache_line.split("=")[1].chomp if cache_line
+                    old_value = cache_line.partition("=").last.chomp if cache_line
                     if !old_value || !equivalent_option_value?(old_value, value)
                         if Autobuild.debug
                             message "%s: option '#{name}' changed value: '#{old_value}' => '#{value}'"


### PR DESCRIPTION
This fix did not make it into the 1.10 branch. Setting -std=cxx11 triggers a rebuild every time.