### PR TITLE
in Autobuild.report, output non-error messages to stdout

### DIFF
--- a/lib/autobuild/reporting.rb
+++ b/lib/autobuild/reporting.rb
@@ -75,7 +75,7 @@ module Autobuild
 
     # Displays a warning message
     def self.warn(message = "", *style)
-        message("  WARN: #{message}", :magenta, *style, STDERR)
+        message("  WARN: #{message}", :magenta, *style, STDOUT)
     end
 
     # @return [Boolean] true if there is some progress messages for the given


### PR DESCRIPTION
Since these are not error messages couldn't they be printed to stdout? This would be better for automated setups.