### PR TITLE
inherit CMAKE_PREFIX_PATH and CMAKE_MODULE_PATH from environment, if set

### DIFF
--- a/lib/autobuild/packages/cmake.rb
+++ b/lib/autobuild/packages/cmake.rb
@@ -49,27 +49,22 @@ module Autobuild
             @@delete_obsolete_files_in_prefix = false
         end
         @builddir = nil
-
-        if Autobuild.env.inherited_environment.has_key?('CMAKE_PREFIX_PATH')
-            @prefix_path = Autobuild.env.inherited_environment['CMAKE_PREFIX_PATH']
-        else
-            @prefix_path = []
-        end
-        if Autobuild.env.inherited_environment.has_key?('CMAKE_MODULE_PATH')
-            @module_path = Autobuild.env.inherited_environment['CMAKE_MODULE_PATH']
-        else
-            @module_path = []
-        end	
+        @prefix_path = []
+        @module_path = []
         @full_reconfigures = true
 
         # a key => value association of defines for CMake
         attr_reader :defines
         # The list of all -D options that should be passed on to CMake
         def all_defines
+            #The String() constuctor handles potential nil Object, need to split(':') to change seperator
+            env_prefix_path = String(Autobuild.env.resolved_env['CMAKE_PREFIX_PATH']).split(':')
+            env_module_path = String(Autobuild.env.resolved_env['CMAKE_MODULE_PATH']).split(':')
+	    
             additional_defines = Hash[
                 "CMAKE_INSTALL_PREFIX" => prefix,
-                "CMAKE_MODULE_PATH" => module_path.join(";"),
-                "CMAKE_PREFIX_PATH" => prefix_path.join(";")]
+                "CMAKE_MODULE_PATH" => (module_path + env_module_path).join(";"),
+                "CMAKE_PREFIX_PATH" => (prefix_path + env_prefix_path).join(";")]
             self.class.defines.merge(additional_defines).merge(defines)
         end
 

--- a/lib/autobuild/packages/cmake.rb
+++ b/lib/autobuild/packages/cmake.rb
@@ -49,8 +49,17 @@ module Autobuild
             @@delete_obsolete_files_in_prefix = false
         end
         @builddir = nil
-        @prefix_path = []
-        @module_path = []
+
+        if Autobuild.env.inherited_environment.has_key?('CMAKE_PREFIX_PATH')
+            @prefix_path = Autobuild.env.inherited_environment['CMAKE_PREFIX_PATH']
+        else
+            @prefix_path = []
+        end
+        if Autobuild.env.inherited_environment.has_key?('CMAKE_MODULE_PATH')
+            @module_path = Autobuild.env.inherited_environment['CMAKE_MODULE_PATH']
+        else
+            @module_path = []
+        end	
         @full_reconfigures = true
 
         # a key => value association of defines for CMake


### PR DESCRIPTION
I'm currently re-enableing the rock-ros bridge, doing this i figured out that 

CMAKE_PREFIX_PATH
CMAKE_MODULE_PATH

Are not inherited from the Environment even if "Autobuild.env_inherit 'CMAKE_PREFIX_PATH'" is set.

Catkin searches the Type generators (gencpp, etc) using the CMAKE_PREFIX_PATH which made the bridge unable to compile, as cmake was called with a clean CMAKE_PREFIX_PATH