### PR TITLE
importer: different message for updated and already up-to-date packages

### DIFF
--- a/lib/autobuild/import/archive.rb
+++ b/lib/autobuild/import/archive.rb
@@ -333,6 +333,7 @@ module Autobuild
             if needs_update || archive_changed?(package)
                 checkout(package, allow_interactive: options[:allow_interactive])
             end
+            (needs_update || archive_changed?(package))
         rescue OpenURI::HTTPError
             raise Autobuild::Exception.new(package.name, :import)
         end

--- a/lib/autobuild/import/cvs.rb
+++ b/lib/autobuild/import/cvs.rb
@@ -36,7 +36,7 @@ module Autobuild
         def update(package, options = Hash.new) # :nodoc:
             if options[:only_local]
                 package.warn "%s: the CVS importer does not support local updates, skipping"
-                return
+                return false
             end
 
             if !File.exist?("#{package.srcdir}/CVS/Root")
@@ -59,6 +59,7 @@ module Autobuild
             end
             package.run(:import, Autobuild.tool(:cvs), 'up', *@options_up,
                         retry: true, working_directory: package.importdir)
+            true # no easy way to check if package was updated, keep previous behavior and consider updated
         end
 
         def checkout(package, options = Hash.new) # :nodoc:

--- a/lib/autobuild/import/darcs.rb
+++ b/lib/autobuild/import/darcs.rb
@@ -25,7 +25,7 @@ module Autobuild
         def update(package, options = Hash.new) # :nodoc:
             if options[:only_local]
                 package.warn "%s: the darcs importer does not support local updates, skipping"
-                return
+                return false
             end
 	    if !File.directory?( File.join(package.srcdir, '_darcs') )
 		raise ConfigException.new(package, 'import'),
@@ -34,6 +34,7 @@ module Autobuild
 
 	    package.run(:import, @program, 
 	       'pull', '--all', "--repodir=#{package.srcdir}", '--set-scripts-executable', @source, *@pull, retry: true)
+            true # no easy to know if package was updated, keep previous behavior
         end
 
         def checkout(package, options = Hash.new) # :nodoc:

--- a/lib/autobuild/import/hg.rb
+++ b/lib/autobuild/import/hg.rb
@@ -52,11 +52,12 @@ module Autobuild
         def update(package, options = Hash.new)
             if options[:only_local]
                 package.warn "%s: the Mercurial importer does not support local updates, skipping"
-                return
+                return false
             end
             validate_importdir(package)
             package.run(:import, Autobuild.tool('hg'), 'pull', repository, retry: true, working_directory: package.importdir)
             package.run(:import, Autobuild.tool('hg'), 'update', branch, working_directory: package.importdir)
+            true # no easy to know if package was updated, keep previous behavior
         end
 
         def checkout(package, options = Hash.new)

--- a/lib/autobuild/import/svn.rb
+++ b/lib/autobuild/import/svn.rb
@@ -197,7 +197,7 @@ module Autobuild
         def update(package, options = Hash.new) # :nodoc:
             if options[:only_local]
                 package.warn "%s: the svn importer does not support local updates, skipping"
-                return
+                return false
             end
 
             url = svn_url(package)
@@ -212,11 +212,12 @@ module Autobuild
                 elsif revision
                     # Don't update if the current revision is greater-or-equal
                     # than the target revision
-                    return
+                    return false
                 end
             end
 
             run_svn(package, 'up', "--non-interactive", *options_up)
+            true
         end
 
         def checkout(package, options = Hash.new) # :nodoc:

--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -301,7 +301,7 @@ class Importer
         retry_count = 0
         package.progress_start "updating %s"
         begin
-            update(package,only_local)
+            did_update = update(package,only_local)
             execute_post_hooks(package)
         rescue Interrupt
             if last_error
@@ -336,7 +336,10 @@ class Importer
             package.message "update failed in #{package.importdir}, retrying (#{retry_count}/#{self.retry_count})"
             retry
         ensure
-            package.progress_done "updated %s"
+            update_msg = if did_update == false then 'already up-to-date'
+                         else 'updated' end
+
+            package.progress_done "#{update_msg} %s"
         end
 
         patch(package)


### PR DESCRIPTION
Not sure what do you think about this but this makes things clearer for the user in my opinion. Personally, I hate not knowing how changed my working tree is after an `aup`. I would have prefered to not print anything when the package is already up-to-date but given that `package.progress_done` is mandatory to tell autobuild that an import is finished, I could not find a way to do that (other than printing empty lines)