### PR TITLE
add the API to export an environment in a way that is programmatically usable

### DIFF
--- a/lib/autobuild/exceptions.rb
+++ b/lib/autobuild/exceptions.rb
@@ -122,5 +122,26 @@ module Autobuild
     class InteractionRequired < RuntimeError; end
 
     class AlreadyFailedError < RuntimeError; end
-end
 
+    # The exception type that is used to report multiple errors that occured
+    # when ignore_errors is set
+    class CompositeException < Autobuild::Exception
+        # The array of exception objects representing all the errors that
+        # occured during the build
+        attr_reader :original_errors
+
+        def initialize(original_errors)
+            @original_errors = original_errors
+        end
+
+        def mail?; true end
+
+        def to_s
+            result = ["#{original_errors.size} errors occured"]
+            original_errors.each_with_index do |e, i|
+                result << "(#{i}) #{e.to_s}"
+            end
+            result.join("\n")
+        end
+    end
+end

--- a/lib/autobuild/reporting.rb
+++ b/lib/autobuild/reporting.rb
@@ -250,28 +250,6 @@ module Autobuild
         end
     end
 
-    # The exception type that is used to report multiple errors that occured
-    # when ignore_errors is set
-    class CompositeException < Autobuild::Exception
-        # The array of exception objects representing all the errors that
-        # occured during the build
-        attr_reader :original_errors
-
-        def initialize(original_errors)
-            @original_errors = original_errors
-        end
-
-        def mail?; true end
-
-        def to_s
-            result = ["#{original_errors.size} errors occured"]
-            original_errors.each_with_index do |e, i|
-                result << "(#{i}) #{e.to_s}"
-            end
-            result.join("\n")
-        end
-    end
-
     ## The reporting module provides the framework # to run commands in
     # autobuild and report errors # to the user
     #

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -150,5 +150,41 @@ module Autobuild
                 assert_equal path, @env.find_executable_in_path('test')
             end
         end
+
+        describe "environment_from_export" do
+            before do
+                @export = Environment::ExportedEnvironment.new(
+                    Hash.new, [], Hash.new)
+            end
+
+            it "imports unset values from the base environment" do
+                assert_equal Hash['BLA' => '1'], Environment.
+                    environment_from_export(@export, 'BLA' => '1')
+            end
+
+            it "gets overriden by 'set' values" do
+                @export.set['BLA'] = ['2']
+                assert_equal Hash['BLA' => '2'], Environment.
+                    environment_from_export(@export, 'BLA' => '1')
+            end
+
+            it "gets deleted by 'unset' values" do
+                @export.unset << 'BLA'
+                assert_equal Hash.new, Environment.
+                    environment_from_export(@export, 'BLA' => '1')
+            end
+
+            it "injects the current value in the placeholder for 'update' values" do
+                @export.update['BLA'] = [['a', 'b', '$BLA', 'c'], []]
+                assert_equal Hash['BLA' => 'a:b:1:c'], Environment.
+                    environment_from_export(@export, 'BLA' => '1')
+            end
+
+            it "returns the without-inheritance value if the current env entry is unset" do
+                @export.update['BLA'] = [['a', 'b', '$BLA', 'c'], ['d', 'e', 'f']]
+                assert_equal Hash['BLA' => 'd:e:f'], Environment.
+                    environment_from_export(@export, Hash.new)
+            end
+        end
     end
 end


### PR DESCRIPTION
I.e. save the data "just before" the generation of the env.sh file,
and provide APIs to re-load and reuse that data later. This is used
by autoproj to cache the environment in a way that can be easily
loaded.