### PR TITLE
Fix git importer test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ rvm:
 matrix:
     allow_failures:
         - rvm: 'jruby-9.1.15.0'
+
+script:
+  - bundle install --path vendor
+  - bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: ruby
 rvm:
   - '2.1'
@@ -11,6 +11,10 @@ matrix:
     allow_failures:
         - rvm: 'jruby-9.1.15.0'
 
+install:
+  - gem install bundler
+  - bundle install --path vendor/bundle
+
 script:
-  - bundle install --path vendor
+  - bundle exec rake
   - bundle exec rake test

--- a/test/import/test_git.rb
+++ b/test/import/test_git.rb
@@ -480,9 +480,9 @@ describe Autobuild::Git do
                 untar('gitrepo-with-extra-commit-and-tag.tar')
                 importer.import(pkg)
                 extra_repo = File.join(tempdir, 'gitrepo-with-extra-commit-and-tag.git')
-                importer.relocate(extra_repo, commit: '1ddb20665622279700770be09f9a291b37c9b631')
+                importer.relocate(extra_repo, commit: 'ba9ec170be55ba4675e2980b6e2da29a4c5797aa')
                 assert importer.import(pkg, reset: false)
-                assert_equal  '1ddb20665622279700770be09f9a291b37c9b631', importer.rev_parse(pkg, 'HEAD')
+                assert_equal  'ba9ec170be55ba4675e2980b6e2da29a4c5797aa', importer.rev_parse(pkg, 'HEAD')
             end
 
             common_commit_and_tag_behaviour

--- a/test/import/test_tar.rb
+++ b/test/import/test_tar.rb
@@ -53,13 +53,14 @@ class TC_TarImporter < Minitest::Test
     def web_server
         s = HTTPServer.new :Port => 2000, :DocumentRoot => tempdir
         s.mount("/files", HTTPServlet::FileHandler, tempdir)
-        Thread.new { s.start }
+        t = Thread.new { s.start }
 
         yield
 
     ensure
         if s
             s.shutdown
+            t.join
         end
     end
 


### PR DESCRIPTION
Just realized that travis was actually not running the tests. So, this:

1. Makes `:test` the default Rake task;
2. Fixes a broken git importer test case 