### PR TITLE
Add jobserver arg fix for gnumake > 4.2

### DIFF
--- a/lib/autobuild/packages/gnumake.rb
+++ b/lib/autobuild/packages/gnumake.rb
@@ -1,12 +1,16 @@
+require 'rubygems/version'
+
 module Autobuild
     def self.make_is_gnumake?(pkg, path = Autobuild.tool(:make))
         @make_is_gnumake ||= Hash.new
+        @gnumake_version ||= Hash.new
         if @make_is_gnumake.has_key?(path)
             @make_is_gnumake[path]
         else
             begin
                 result = pkg.run('prepare', path, '--version')
                 @make_is_gnumake[path] = (result.first =~ /GNU Make/)
+                @gnumake_version[path] = result.first.scan(/[\d.]+/)[0]
             rescue Autobuild::SubcommandFailed
                 @make_is_gnumake[path] = false
             end
@@ -31,7 +35,11 @@ module Autobuild
                     job_server.get(reserved - 1) # We already have one token taken by autobuild itself
                     yield("-j#{pkg.parallel_build_level}")
                 end
-                yield("--jobserver-fds=#{job_server.rio.fileno},#{job_server.wio.fileno}", "-j")
+                if Gem::Version.new(@gnumake_version[cmd_path]) >= Gem::Version.new("4.2.0")
+                    yield("--jobserver-auth=#{job_server.rio.fileno},#{job_server.wio.fileno}", "-j")
+                else
+                    yield("--jobserver-fds=#{job_server.rio.fileno},#{job_server.wio.fileno}", "-j")
+                end
             end
             yield("-j#{pkg.parallel_build_level}")
         else yield


### PR DESCRIPTION
From the changelogs of gnumake:

WARNING: Backward-incompatibility! The internal-only command line option
  --jobserver-fds has been renamed for publishing, to --jobserver-auth.

https://lists.gnu.org/archive/html/info-gnu/2016-05/msg00013.html