### PR TITLE
Hash generation and validations for packages

### DIFF
--- a/lib/autobuild/import/archive.rb
+++ b/lib/autobuild/import/archive.rb
@@ -282,6 +282,10 @@ module Autobuild
             end
         end
 
+        def fingerprint(package)
+            digest
+        end
+
         # The source URL
         attr_reader :url
         # The local file (either a downloaded file if +url+ is not local, or +url+ itself)

--- a/lib/autobuild/import/archive.rb
+++ b/lib/autobuild/import/archive.rb
@@ -271,14 +271,19 @@ module Autobuild
         def read_cachefile_digest
             Digest::SHA1.hexdigest File.read(cachefile)
         end
-
+        
+        # Fingerprint for archive importer, we are using
+        # its digest whether is calculated or expected
+        # @raises ConfigException if no digest is present
         def fingerprint(package)
             if @cachefile_digest
                 @cachefile_digest
             elsif File.file?(cachefile)
                 read_cachefile_digest
-            else
+            elsif @expected_digest
                 @expected_digest
+            else
+                raise ConfigException, "There is no digest for archive #{@url.to_s}, make sure cache directories are configured correctly"
             end
         end
 

--- a/lib/autobuild/import/archive.rb
+++ b/lib/autobuild/import/archive.rb
@@ -257,6 +257,7 @@ module Autobuild
         # Updates the downloaded file in cache only if it is needed
         #
         # @return [Boolean] true if a new file was downloaded, false otherwise
+        # @raises ConfigException if a expected digest was given in the source.yml file and it doesn't match
         def update_cache(package)
             updated = download_from_url(package)
             @cachefile_digest = read_cachefile_digest

--- a/lib/autobuild/import/archive.rb
+++ b/lib/autobuild/import/archive.rb
@@ -276,7 +276,7 @@ module Autobuild
         # Fingerprint for archive importer, we are using
         # its digest whether is calculated or expected
         # @raises ConfigException if no digest is present
-        def fingerprint(package)
+        def vcs_fingerprint(package)
             if @cachefile_digest
                 @cachefile_digest
             elsif File.file?(cachefile)

--- a/lib/autobuild/import/archive.rb
+++ b/lib/autobuild/import/archive.rb
@@ -272,7 +272,7 @@ module Autobuild
             Digest::SHA1.hexdigest File.read(cachefile)
         end
 
-        def digest
+        def fingerprint(package)
             if @cachefile_digest
                 @cachefile_digest
             elsif File.file?(cachefile)
@@ -280,10 +280,6 @@ module Autobuild
             else
                 @expected_digest
             end
-        end
-
-        def fingerprint(package)
-            digest
         end
 
         # The source URL

--- a/lib/autobuild/import/git.rb
+++ b/lib/autobuild/import/git.rb
@@ -152,6 +152,10 @@ module Autobuild
             @additional_remotes = Array.new
         end
 
+        def fingerprint(package)
+            rev_parse(package, 'HEAD')
+        end
+
         # The name of the remote that should be set up by the importer
         #
         # Defaults to 'autobuild'

--- a/lib/autobuild/import/git.rb
+++ b/lib/autobuild/import/git.rb
@@ -152,7 +152,7 @@ module Autobuild
             @additional_remotes = Array.new
         end
 
-        def fingerprint(package)
+        def vcs_fingerprint(package)
             rev_parse(package, 'HEAD')
         end
 

--- a/lib/autobuild/import/svn.rb
+++ b/lib/autobuild/import/svn.rb
@@ -75,7 +75,7 @@ module Autobuild
         # @param [Package] package
         # @return [String]
         # @raises (see svn_info)
-        def fingerprint(package)
+        def vcs_fingerprint(package)
             Digest::SHA1.hexdigest(svn_info(package).grep(/^(URL|Revision):/).sort.join("\n"))
         end
 

--- a/lib/autobuild/import/svn.rb
+++ b/lib/autobuild/import/svn.rb
@@ -70,6 +70,12 @@ module Autobuild
             Integer($1)
         end
 
+        # fingerprint method returns an unique hash to identify this package,
+        # for SVN the revision will be used
+        def fingerprint(package)
+            svn_revision(package).to_s
+        end
+
         # Returns the URL of the remote SVN repository
         #
         # @param [Package] package

--- a/lib/autobuild/import/svn.rb
+++ b/lib/autobuild/import/svn.rb
@@ -76,8 +76,7 @@ module Autobuild
         # @return [String]
         # @raises (see svn_info)
         def fingerprint(package)
-            url = svn_url(package)
-            return Digest::SHA1.hexdigest url + svn_revision(package).to_s
+            Digest::SHA1.hexdigest(svn_info(package).grep(/^(URL|Revision):/).sort.join("\n"))
         end
 
         # Returns the URL of the remote SVN repository

--- a/lib/autobuild/import/svn.rb
+++ b/lib/autobuild/import/svn.rb
@@ -71,9 +71,13 @@ module Autobuild
         end
 
         # fingerprint method returns an unique hash to identify this package,
-        # for SVN the revision will be used
+        # for SVN the revision and URL will be used
+        # @param [Package] package
+        # @return [String]
+        # @raises (see svn_info)
         def fingerprint(package)
-            svn_revision(package).to_s
+            url = svn_url(package)
+            return Digest::SHA1.hexdigest url + svn_revision(package).to_s
         end
 
         # Returns the URL of the remote SVN repository

--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -204,7 +204,7 @@ class Importer
     def fingerprint(package)
         #each importer type should implement its own 
         Autoproj.warn "Fingerprint has not been implemented for this type of packages, results should be discarded"
-        return
+        return ""
     end
 
     def patches

--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -201,6 +201,12 @@ class Importer
         @options[:retry_count] = Integer(count)
     end
 
+    def fingerprint(package)
+        #each importer type should implement its own 
+        Autoproj.warn "Fingerprint has not been implemented for this type of packages, results should be discarded"
+        return
+    end
+
     def patches
         patches =
             if @options[:patches].respond_to?(:to_ary)

--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -201,10 +201,11 @@ class Importer
         @options[:retry_count] = Integer(count)
     end
 
+    # Returns a unique hash representing the state of the imported package
     def fingerprint(package)
         #each importer type should implement its own 
-        Autoproj.warn "Fingerprint has not been implemented for this type of packages, results should be discarded"
-        return ""
+        Autoproj.warn "Fingerprint in #{package.name} has not been implemented for this type of packages, results should be discarded"
+        return nil
     end
 
     def patches

--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -202,10 +202,31 @@ class Importer
     end
 
     # Returns a unique hash representing the state of the imported package
+    # as a whole unit, including its dependencies and patches
     def fingerprint(package)
+        vcs_fingerprint_string = vcs_fingerprint(package)
+        return unless vcs_fingerprint_string
+
+        patches_fingerprint_string = patches_fingerprint(package)
+        if patches_fingerprint_string
+            Digest::SHA1.hexdigest(vcs_fingerprint_string + patches_fingerprint_string)
+        elsif patches.empty?
+            vcs_fingerprint_string
+        end
+    end
+
+    # basic fingerprint of the package and its dependencies
+    def vcs_fingerprint(package)
         #each importer type should implement its own 
         Autoproj.warn "Fingerprint in #{package.name} has not been implemented for this type of packages, results should be discarded"
         return nil
+    end
+
+    # fingerprint for patches associated to this package
+    def patches_fingerprint(package)
+        cur_patches = currently_applied_patches(package)
+        cur_patches.map(&:shift) #leave only level and source information
+        Digest::SHA1.hexdigest(cur_patches.sort.flatten.join("")) if !patches.empty? && cur_patches
     end
 
     def patches

--- a/lib/autobuild/package.rb
+++ b/lib/autobuild/package.rb
@@ -618,6 +618,15 @@ module Autobuild
             end
         end
 
+        def fingerprint(recursive: true)
+            concatenate_fingerprints = importer.fingerprint(self)
+            dependencies.each do |pkg_name|
+                pkg = Autobuild::Package[pkg_name]
+                concatenate_fingerprints += pkg.importer.fingerprint(pkg)
+            end
+            Digest::SHA1.hexdigest concatenate_fingerprints
+        end
+
         # Returns the name of all the packages +self+ depends on
         def all_dependencies(result = Set.new)
             dependencies.each do |pkg_name|

--- a/lib/autobuild/package.rb
+++ b/lib/autobuild/package.rb
@@ -627,12 +627,12 @@ module Autobuild
             return unless self_fingerprint
 
             memo[name] = self_fingerprint
-            return self_fingerprint unless recursive
+            return self_fingerprint if !recursive || dependencies.empty?
 
             dependency_fingerprints = dependencies.sort.map do |pkg_name|
                 pkg = Autobuild::Package[pkg_name]
                 unless (fingerprint = memo[pkg.name])
-                    fingerprint = pkg.fingerprint(memo: memo)
+                    fingerprint = pkg.fingerprint(recursive: true, memo: memo)
                     return unless fingerprint
                     memo[pkg.name] = fingerprint
                 end

--- a/test/import/test_git.rb
+++ b/test/import/test_git.rb
@@ -648,6 +648,14 @@ describe Autobuild::Git do
         end
     end
 
+    describe "fingerprint generation" do
+        it "returns the expected commit ID of HEAD" do
+            importer.import(pkg)
+            expected_fingerprint = importer.rev_parse(pkg, 'HEAD')
+            assert_equal expected_fingerprint, importer.fingerprint(pkg)
+        end
+    end
+
     def assert_checkout_file_exist(*file)
         assert File.exist?(checkout_path(*file))
     end

--- a/test/import/test_svn.rb
+++ b/test/import/test_svn.rb
@@ -142,13 +142,32 @@ describe Autobuild::SVN do
     end
 
     describe "fingerprint generation" do
-        it "returns the expected value" do
-            current_revision = 2
-            importer = Autobuild.svn(svnroot, revision: current_revision)
-            importer.import(pkg_svn)
+        before do
+            current_revision = '2'
+            @importer = Autobuild.svn(svnroot, revision: current_revision)
             expected_source_string = "Revision: "+current_revision+"\nURL: "+svnroot
-            expected_fingerprint = Digest::SHA1.hexdigest(expected_source_string)
-            assert_equal expected_fingerprint, importer.fingerprint(pkg_svn)
+            @expected_vcs_fingerprint = Digest::SHA1.hexdigest(expected_source_string)
+            @importer.import(pkg_svn)
+        end
+        it "returns the expected value" do
+            assert_equal @expected_vcs_fingerprint, @importer.fingerprint(pkg_svn)
+        end
+        it "computes also the patches' fingerprint" do
+            test_patches = [['/path/to/patch', 1, 'source_test'],['other/path', 2, 'source2_test']]
+            # we expect paths will be ignored and the patches array to be
+            # flatenned into a string
+            expected_patch_fingerprint = Digest::SHA1.hexdigest('1source_test2source2_test')
+            flexmock(@importer).
+                should_receive(:currently_applied_patches).
+                and_return(test_patches)
+            flexmock(@importer).
+                should_receive(:patches).
+                and_return(test_patches)
+            
+            expected_fingerprint = Digest::SHA1.hexdigest(@expected_vcs_fingerprint + 
+                expected_patch_fingerprint)
+
+            assert_equal expected_fingerprint, @importer.fingerprint(pkg_svn)
         end
     end
 

--- a/test/import/test_svn.rb
+++ b/test/import/test_svn.rb
@@ -140,5 +140,17 @@ describe Autobuild::SVN do
             assert importer.status(pkg_svn).uncommitted_code
         end
     end
+
+    describe "fingerprint generation" do
+        it "returns the expected value" do
+            current_revision = 2
+            importer = Autobuild.svn(svnroot, revision: current_revision)
+            importer.import(pkg_svn)
+            expected_source_string = "Revision: "+current_revision+"\nURL: "+svnroot
+            expected_fingerprint = Digest::SHA1.hexdigest(expected_source_string)
+            assert_equal expected_fingerprint, importer.fingerprint(pkg_svn)
+        end
+    end
+
 end
  

--- a/test/test_package.rb
+++ b/test/test_package.rb
@@ -79,6 +79,98 @@ module Autobuild
                 assert_equal ops, package.resolve_dependency_env(env, set, ops)
             end
         end
+
+        describe "#fingerprint_generation" do
+            attr_reader :package
+            before do
+                @pkg0 = Package.new('pkg0')
+                @pkg0.importer = Importer.new \
+                    interactive: false
+                
+                @pkg1 = Package.new('pkg1')
+                @pkg1.importer = Importer.new \
+                    interactive: false
+                
+                @dep_pkg0 = Package.new('dep_pkg0')
+                @dep_pkg1 = Package.new('dep_pkg1')
+
+                @dep_pkg0.importer = Importer.new \
+                    interactive: false
+                @dep_pkg1.importer = Importer.new \
+                    interactive: false
+                
+            end
+
+            it "return nil when the package's importer does not compute a fingerprint" do
+                flexmock(@pkg0.importer).should_receive(:fingerprint).
+                    and_return(nil)
+                assert_nil @pkg0.fingerprint  
+            end
+
+            it "return importer's fingerprint when there are no dependencies" do
+                flexmock(@pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder")
+                assert_equal "fingerprint_placeholder", @pkg0.fingerprint  
+            end
+
+            it "returns nil if one of the dependencies has no fingerprint" do
+                flexmock(@pkg0).should_receive(:dependencies).
+                    and_return(['dep_pkg0', 'dep_pkg1'])
+
+                flexmock(@pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder")
+                flexmock(@dep_pkg0.importer).should_receive(:fingerprint).
+                    and_return(nil)
+                flexmock(@dep_pkg1.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_pkg1")
+
+                assert_nil @pkg0.fingerprint  
+            end
+
+            it "fingerprints should be the same no matter the order of the dependencies" do
+                flexmock(@pkg0).should_receive(:dependencies).
+                    and_return(['dep_pkg0', 'dep_pkg1'])
+
+                flexmock(@pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder")
+                flexmock(@dep_pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_pkg0")
+                flexmock(@dep_pkg1.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_pkg1")
+
+                fingerprint_pkg0_pk1 = @pkg0.fingerprint  
+
+                flexmock(@pkg1).should_receive(:dependencies).
+                    and_return(['dep_pkg1', 'dep_pkg0'])
+
+                flexmock(@pkg1.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder")
+                flexmock(@dep_pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_pkg0")
+                flexmock(@dep_pkg1.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_pkg1")
+
+                fingerprint_pkg1_pk0 = @pkg1.fingerprint  
+
+                assert_equal fingerprint_pkg0_pk1, fingerprint_pkg1_pk0
+            end
+
+            it "returns expected fingerprint" do
+                flexmock(@pkg0).should_receive(:dependencies).
+                    and_return(['dep_pkg0', 'dep_pkg1'])
+
+                flexmock(@pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_pkg0")
+                flexmock(@dep_pkg0.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_dep_pkg0")
+                flexmock(@dep_pkg1.importer).should_receive(:fingerprint).
+                    and_return("fingerprint_placeholder_dep_pkg1")
+
+                expected_fingerprint = Digest::SHA1.hexdigest("fingerprint_placeholder_pkg0fingerprint_placeholder_dep_pkg0fingerprint_placeholder_dep_pkg1")
+                assert_equal expected_fingerprint, @pkg0.fingerprint  
+            end
+
+        end
     end
 end
 


### PR DESCRIPTION
Added new option for archive packages, expected digest using SHA1. The package does not do any checkout if the digests don't match. Also added new fingerprint property for importers, and a fingerprint property for packages, which hashes the contents, in order to use for verification and cache with external CI tools.