### PR TITLE
fix git lfs availability check method

### DIFF
--- a/lib/autobuild/import/git.rb
+++ b/lib/autobuild/import/git.rb
@@ -1160,7 +1160,7 @@ module Autobuild
         def self.lfs_installed?
             return @lfs_installed unless @lfs_installed.nil?
 
-            _, _, status = Open3.capture3('git lfs env')
+            _, _, status = Open3.capture3('git lfs')
             @lfs_installed = status.success?
         end
 


### PR DESCRIPTION
`git lfs env` creates an annoying `lfs` dir in the working dir... `git lfs` is enough and has no side effects