### PR TITLE
do not pass -j to Make >= 4.2.0

### DIFF
--- a/lib/autobuild/packages/gnumake.rb
+++ b/lib/autobuild/packages/gnumake.rb
@@ -59,7 +59,7 @@ module Autobuild
 
         version = gnumake_version(pkg, path)
         if version >= GNUMAKE_JOBSERVER_AUTH_VERSION
-            ["--jobserver-auth=#{jobserver_fds_arg}", "-j"]
+            ["--jobserver-auth=#{jobserver_fds_arg}"]
         else
             ["--jobserver-fds=#{jobserver_fds_arg}", "-j"]
         end

--- a/test/packages/test_gnumake.rb
+++ b/test/packages/test_gnumake.rb
@@ -92,14 +92,14 @@ module Autobuild
                 )
             end
 
-            it "returns --jobserver-auth for GNU make after 4.2.0" do
+            it "returns --jobserver-auth and no -j for GNU make after 4.2.0" do
                 flexmock(Autobuild).should_receive(:gnumake_version)
                     .with(@pkg, 'toolpath')
                     .and_return(Gem::Version.new("4.2.0"))
                 options = Autobuild.gnumake_jobserver_option(
                     @job_server, @pkg, 'toolpath'
                 )
-                assert_equal ["--jobserver-auth=42,21", "-j"], options
+                assert_equal ["--jobserver-auth=42,21"], options
             end
 
             it "returns --jobserver-fds for GNU make before 4.2.0" do
@@ -170,7 +170,7 @@ module Autobuild
                 @job_server.should_receive(rio: flexmock(fileno: 42))
                 @job_server.should_receive(wio: flexmock(fileno: 21))
 
-                @recorder.should_receive(:record).with(["--jobserver-auth=42,21", "-j"])
+                @recorder.should_receive(:record).with(["--jobserver-auth=42,21"])
                          .once.globally.ordered
                 Autobuild.invoke_make_parallel(@pkg, 'toolpath') do |*args|
                     @recorder.record(args)


### PR DESCRIPTION
Passing -j actually disables the job server (and is interpreted as "spawn as many processes as you'd like")