### PR TITLE
git: disable auto-use of cache if submodules are enabled

### DIFF
--- a/lib/autobuild/import/git.rb
+++ b/lib/autobuild/import/git.rb
@@ -24,6 +24,11 @@ module Autobuild
             # AUTOBUILD_GIT_CACHE_DIR and AUTOBUILD_CACHE_DIR environment
             # variables
             #
+            # Because of its role within the caching system in autobuild/autoproj,
+            # these defaults are not applied to git repositories that are using
+            # submodules. The autoproj cache builder does not generate repositories
+            # compatible with having submodules
+            #
             # @return [Array]
             # @see default_alternates=, Git#alternates
             def default_alternates
@@ -111,7 +116,6 @@ module Autobuild
         #   workflow, it is recommended to not use submodules but checkout all
         #   repositories separately instead.
         def initialize(repository, branch = nil, options = {})
-            @alternates = Git.default_alternates.dup
             @git_dir_cache = Array.new
             @local_branch = @remote_branch = nil
             @tag = @commit = nil
@@ -155,6 +159,13 @@ module Autobuild
 
             @single_branch = gitopts[:single_branch]
             @with_submodules = gitopts.delete(:with_submodules)
+            @alternates =
+                if @with_submodules
+                    []
+                else
+                    Git.default_alternates.dup
+                end
+
             @remote_name = 'autobuild'
             @push_to = nil
             relocate(repository, gitopts)

--- a/test/import/test_git.rb
+++ b/test/import/test_git.rb
@@ -33,6 +33,16 @@ describe Autobuild::Git do
             assert_equal "master", git.local_branch
             assert_equal "test", git.remote_branch
         end
+        it 'picks the default alternates by default' do
+            flexmock(Autobuild::Git, default_alternates: (alt = [flexmock]))
+            git = Autobuild::Git.new('repo')
+            assert_equal alt, git.alternates
+        end
+        it 'does not pick the default alternates if the importer is set up to use submodules' do
+            flexmock(Autobuild::Git, default_alternates: (alt = [flexmock]))
+            git = Autobuild::Git.new('repo', with_submodules: true)
+            assert_equal [], git.alternates
+        end
     end
 
     describe "#relocate" do
@@ -671,7 +681,7 @@ describe Autobuild::Git do
             # flatenned into a string
             expected_patch_fingerprint = Digest::SHA1.hexdigest('1source_test2source2_test')
 
-            expected_fingerprint = Digest::SHA1.hexdigest(@expected_vcs_fingerprint + 
+            expected_fingerprint = Digest::SHA1.hexdigest(@expected_vcs_fingerprint +
                 expected_patch_fingerprint)
 
             assert_equal expected_fingerprint, importer.fingerprint(pkg)


### PR DESCRIPTION
The way the cache is built with `autoproj cache` is currently
not compatible with submodules. Just disable caching if submodules
are used