### PR TITLE
fix Importer.default_cache_dirs in case the default dir is set explicitly

### DIFF
--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -107,7 +107,11 @@ module Autobuild
         # @return [Array<String>,nil]
         # @see .cache_dirs
         def self.default_cache_dirs
-            [@default_cache_dirs] if @default_cache_dirs ||= ENV['AUTOBUILD_CACHE_DIR']
+            if @default_cache_dirs
+                @default_cache_dirs
+            elsif (from_env = ENV['AUTOBUILD_CACHE_DIR'])
+                @default_cache_dirs = [from_env]
+            end
         end
 
         # Sets the cache directory for a given importer type

--- a/test/test_importer.rb
+++ b/test/test_importer.rb
@@ -60,10 +60,13 @@ module Autobuild
                     ENV['AUTOBUILD_TEST_CACHE_DIR'] = '/specific_env'
                     ENV['AUTOBUILD_CACHE_DIR'] = '/global_env'
                 end
-                it "defaults to the specific value if known" do
+                it 'normalizes default_cache_dirs to an array' do
+                    assert_equal ['/global'], Importer.default_cache_dirs
+                end
+                it 'defaults to the specific value if known' do
                     assert_equal ['/specific'], Importer.cache_dirs('test')
                 end
-                it "falls back to the global value otherwise" do
+                it 'falls back to the global value otherwise' do
                     assert_equal ['/global/bla'], Importer.cache_dirs('bla')
                 end
             end


### PR DESCRIPTION
It would lead to a double array