### PR TITLE
add a 'newline' progress mode and a rate-limit for progress messages

### DIFF
--- a/autobuild.gemspec
+++ b/autobuild.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency "flexmock", '~> 2.0', ">= 2.0.0"
     s.add_development_dependency "minitest", "~> 5.0", ">= 5.0"
     s.add_development_dependency "simplecov"
+    s.add_development_dependency "timecop"
 end

--- a/lib/autobuild/reporting.rb
+++ b/lib/autobuild/reporting.rb
@@ -47,8 +47,17 @@ module Autobuild
         @display.progress_enabled?
     end
 
+    # @deprecated use {progress_display_mode=} instead
     def self.progress_display_enabled=(value)
         @display.progress_enabled = value
+    end
+
+    def self.progress_display_mode=(value)
+        @display.progress_mode = value
+    end
+
+    def self.progress_display_period=(value)
+        @display.progress_period = value
     end
 
     def self.message(*args, **options)

--- a/test/test_progress_display.rb
+++ b/test/test_progress_display.rb
@@ -1,9 +1,14 @@
 require 'autobuild/test'
+require 'timecop'
 
 module Autobuild
     describe ProgressDisplay do
+        after do
+            Timecop.return
+        end
+
         describe "#silent" do
-             before do
+            before do
                 @io = StringIO.new
                 @formatter = ProgressDisplay.new(@io)
             end
@@ -12,6 +17,84 @@ module Autobuild
                 @formatter.silent = false
                 @formatter.silent { }
                 refute @formatter.silent?
+            end
+        end
+
+        describe 'the progress mode' do
+            before do
+                @io = StringIO.new
+                @display = ProgressDisplay.new(@io)
+                @display.progress_period = 0
+                @display.progress_start :key, 'start'
+                @io.string.clear
+                @io.rewind
+            end
+            it 'does not output any progress message if the mode is off' do
+                @display.progress_mode = 'off'
+                @display.progress :key, 'progress 0'
+                assert @io.string.empty?
+            end
+
+            it 'clears the last message and replaces it with the new one if mode is single_line' do
+                @display.progress_mode = 'single_line'
+                @display.progress :key, 'progress 0'
+                @display.progress :key, 'progress 1'
+                expected = "#{TTY::Cursor.clear_screen_down}  progress 0"\
+                           "#{TTY::Cursor.column(0)}"\
+                           "#{TTY::Cursor.clear_screen_down}  progress 1"\
+                           "#{TTY::Cursor.column(0)}"
+                assert_equal expected, @io.string
+            end
+
+            it 'outputs messages on new lines if mode is newline' do
+                @display.progress_mode = 'newline'
+                @display.progress :key, 'progress 0'
+                @display.progress :key, 'progress 1'
+                assert_equal "  progress 0\n  progress 1\n", @io.string
+            end
+        end
+
+        describe 'the progress period' do
+            before do
+                @io = StringIO.new
+                @display = ProgressDisplay.new(@io)
+                @display.progress_period = 1
+                @display.progress_mode = 'newline'
+            end
+
+            it 'does not display progress messages that come quicker than the period' do
+                Timecop.freeze(now = Time.now)
+                @display.progress_start :key, 'start'
+                Timecop.freeze(now + 0.1)
+                @display.progress :key, 'progress 1'
+                Timecop.freeze(now + 0.5)
+                @display.progress :key, 'progress 2'
+                Timecop.freeze(now + 1.01)
+                @display.progress :key, 'progress 3'
+
+                assert_equal "  start\n  progress 3\n", @io.string
+            end
+
+            it 'displays normal messages regardless of the period' do
+                Timecop.freeze(now = Time.now)
+                @display.progress_start :key, 'start'
+                Timecop.freeze(now + 0.1)
+                @display.message 'msg'
+
+                assert_equal "  start\nmsg\n", @io.string
+            end
+
+            it 'displays start and stop messages regardless of the period' do
+                Timecop.freeze(now = Time.now)
+                @display.progress_start :key0, 'start 0'
+                Timecop.freeze(now + 0.1)
+                @display.progress_start :key1, 'start 1'
+                Timecop.freeze(now + 0.2)
+                @display.progress_done :key0, message: 'done 0'
+                Timecop.freeze(now + 0.3)
+                @display.progress_done :key1, message: 'done 1'
+
+                assert_equal "  start 0\n  start 0, 1\n  done 0\n  done 1\n", @io.string
             end
         end
 


### PR DESCRIPTION
This is to make the output more suited for CI. CI environments all
have 'no output' timeouts (and for good reasons). Disabling progress
completely doesn't work well for long builds, and having the progress
just outputs a mess on most console displays.

The new mode will display progress, but with each new progress line
on a single line. Along with the rate-limiting, it allows to know
that things are progressing without having a build log that's unreadable.