### PR TITLE
utility: allow disabling the copy-results behavior

### DIFF
--- a/lib/autobuild/test_utility.rb
+++ b/lib/autobuild/test_utility.rb
@@ -73,7 +73,8 @@ module Autobuild
         def coverage_target_dir
             if @coverage_target_dir
                 File.expand_path(@coverage_target_dir, package.prefix)
-            else File.join(target_dir, 'coverage')
+            elsif (target_dir = self.target_dir)
+                File.join(target_dir, 'coverage')
             end
         end
 

--- a/test/test_test_utility.rb
+++ b/test/test_test_utility.rb
@@ -1,0 +1,31 @@
+require 'autobuild/test'
+
+module Autobuild
+    describe TestUtility do
+        before do
+            @package = Package.new 'pkg'
+            @utility = TestUtility.new('test', @package)
+        end
+
+        describe '#coverage_target_dir' do
+            it 'defaults to the utility\'s target dir' do
+                @utility.target_dir = '/some/path'
+                assert_equal '/some/path/coverage', @utility.coverage_target_dir
+            end
+
+            it 'may be set explicitly' do
+                @utility.target_dir = '/some/path'
+                @utility.coverage_target_dir = '/some/other/path'
+                assert_equal '/some/other/path', @utility.coverage_target_dir
+            end
+
+            it 'roots explicit target dir on the package prefix' do
+                @package.prefix = '/package'
+                @utility.target_dir = '/some/path'
+                @utility.coverage_target_dir = 'some/other/path'
+                assert_equal '/package/some/other/path', @utility.coverage_target_dir
+            end
+        end
+    end
+end
+

--- a/test/test_utility.rb
+++ b/test/test_utility.rb
@@ -7,30 +7,100 @@ module Autobuild
             @utility = Utility.new('test', @package)
         end
 
+        describe '#available?' do
+            it 'is false by default' do
+                refute @utility.available?
+            end
+
+            it 'is false if only a block is defined' do
+                @utility.task { }
+                refute @utility.available?
+            end
+
+            it 'is false if only a source dir is defined' do
+                @utility.source_dir = '/some/path'
+                refute @utility.available?
+            end
+
+            it 'is false if only no_results is set' do
+                @utility.no_results = true
+                refute @utility.available?
+            end
+
+            it 'is true if a block has been defined and the source dir is set' do
+                @utility.task { }
+                @utility.source_dir = '/some/path'
+                assert @utility.available?
+            end
+
+            it 'is true if a block has been defined and no_results is set' do
+                @utility.task { }
+                @utility.no_results = true
+                assert @utility.available?
+            end
+
+            it 'may be forcefully set to false' do
+                @utility.task { }
+                @utility.source_dir = '/some/path'
+                @utility.available = false
+                refute @utility.available?
+            end
+        end
+
+        describe "#enabled" do
+            it 'is true by default even if available? is true' do
+                flexmock(@utility).should_receive(available?: true)
+                assert @utility.enabled?
+            end
+
+            it 'is always false if available? is false' do
+                flexmock(@utility).should_receive(available?: false)
+                @utility.enabled = true
+                refute @utility.enabled?
+            end
+
+            it 'is may be forcefully set to false' do
+                flexmock(@utility).should_receive(available?: true)
+                @utility.enabled = false
+                refute @utility.enabled?
+            end
+        end
+
         describe '#call_task_block' do
             before do
                 @utility.source_dir = '/some/dir'
             end
 
-            it 'warns if the block did not create the output directory' do
-                flexmock(@package)
-                @package.should_receive(:warn).with("%s: failed to call test").once
-                @package.should_receive(:warn)
-                        .with(%r{^%s: /some/dir was expected to be a directory}).once
-                @utility.call_task_block
+            describe 'with a result directory' do
+                it 'warns if the block did not create the output directory' do
+                    flexmock(@package)
+                    @package.should_receive(:warn).with("%s: failed to call test").once
+                    @package.should_receive(:warn)
+                            .with(%r{^%s: /some/dir was expected to be a directory}).once
+                    @utility.call_task_block
+                end
+
+                it 'attempts an install if the block raised and install_on_error is set' do
+                    flexmock(@utility, install_on_error?: true)
+                    @utility.should_receive(:install).once
+                    @utility.task { raise "something" }
+                    @utility.call_task_block
+                end
+
+                it 'does not attempt a second install if the install step failed' do
+                    flexmock(@utility, install_on_error?: true)
+                    @utility.should_receive(:install).once.and_raise(RuntimeError)
+                    @utility.call_task_block
+                end
             end
 
-            it 'attempts an install if the block raised and install_on_error is set' do
-                flexmock(@utility, install_on_error?: true)
-                @utility.should_receive(:install).once
-                @utility.task { raise "something" }
-                @utility.call_task_block
-            end
-
-            it 'does not attempt a second install if the install step failed' do
-                flexmock(@utility, install_on_error?: true)
-                @utility.should_receive(:install).once.and_raise(RuntimeError)
-                @utility.call_task_block
+            describe 'with no_results set' do
+                it 'does not warn and does not attempt to install' do
+                    @utility.no_results = true
+                    flexmock(@package).should_receive(:warn).never
+                    flexmock(@utility).should_receive(:install).never
+                    @utility.call_task_block
+                end
             end
         end
     end


### PR DESCRIPTION
Packages will commonly (i.e. outside of Rock) only rely on their
standard output. It's sub-optimal, but we can't fix all packages
out there to get the JUnit output *we* want.