### PR TITLE
change the locking scheme in progress display

### DIFF
--- a/autobuild.gemspec
+++ b/autobuild.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
     s.files = `git ls-files -z`.split("\x0")
         .reject { |f| f.match(%r{^(test|spec|features)/}) }
 
-    s.add_runtime_dependency 'pastel', '~> 0.7.0'
+    s.add_runtime_dependency "concurrent-ruby", "~> 1.1"
+    s.add_runtime_dependency "pastel", "~> 0.7.0"
     s.add_runtime_dependency "rake", "~> 13.0"
     s.add_runtime_dependency 'tty-cursor', '~> 0.7.0'
     s.add_runtime_dependency 'tty-prompt', '~> 0.21.0'

--- a/lib/autobuild/reporting.rb
+++ b/lib/autobuild/reporting.rb
@@ -47,6 +47,10 @@ module Autobuild
         @display.progress_enabled?
     end
 
+    def self.progress_display_synchronize(&block)
+        @display.synchronize(&block)
+    end
+
     # @deprecated use {progress_display_mode=} instead
     def self.progress_display_enabled=(value)
         @display.progress_enabled = value


### PR DESCRIPTION
The current scheme works fine ... except if one wants to have
interactive schemes (i.e. prompting the user). The prompt
will need to get the display lock, which will block anything
that calls progress_start/_stop or message (e.g. a parallel
update process).

Change the locking mechanism to have all front-facing APIs
be non-blocking. The display methods now queue their changes,
and are responsible for ultimately calling `refresh_display`.
Whomever can lock the display mutex will then display everything
at once.

This way, a prompt can be done under lock, and everything that
was to be displayed while it is locking will be displayed
after.