### PR TITLE
python: store user site for laer use

### DIFF
--- a/test/packages/test_python.rb
+++ b/test/packages/test_python.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'autobuild/test'
+
+module Autobuild
+    describe Python do
+        attr_reader :root_dir, :package, :prefix
+
+        before do
+            @root_dir = make_tmpdir
+            @package = Autobuild.python :package
+            @prefix = File.join(root_dir, "python-prefix")
+
+            package.prefix = @prefix
+        end
+
+        it "stores user site for later use" do
+            output = flexmock
+            status = flexmock
+            output.should_receive(:read).and_return("/lib/python3/site-packages")
+            status.should_receive("value.success?").and_return(true)
+            flexmock(Open3).should_receive(:popen3)
+                           .and_return([nil, output, nil, status])
+                           .once
+
+            package.python_path
+            assert_equal File.join(prefix, "lib", "python3", "site-packages"),
+                         package.python_path
+        end
+    end
+end


### PR DESCRIPTION
```
$ time autoproj envsh
  environment already up-to-date

real	0m7.329s
user	0m5.657s
sys	0m1.556s
$ time autoproj envsh
  environment already up-to-date

real	0m3.284s
user	0m2.790s
sys	0m0.439s
$ grep "Autobuild::Python" .autoproj/installation-manifest | wc -l
72
```

First without the patch and then with the patch.