### PR TITLE
Add lib/pkgconfig to default_pkgconfig_search_suffixes

### DIFF
--- a/lib/autobuild/environment.rb
+++ b/lib/autobuild/environment.rb
@@ -719,6 +719,11 @@ module Autobuild
                     .grep(PKGCONFIG_PATH_RX)
                     .map { |l| l.gsub(PKGCONFIG_PATH_RX, '\1') }
                     .to_set
+                    .add("/lib/pkgconfig")
+            # /lib/pkgconfig is added for packages that always install their
+            # libraries in /lib/ instead of the system mandated directory
+            # (/lib/x86_64-linux-gnu/ for 64bit x86 ubuntu multiarch,
+            # /lib64/ for some other 64bit systems)
         end
 
         # Updates the environment when a new prefix has been added


### PR DESCRIPTION
This change is related to issue #118, adding the /lib/pkgconfig suffix hardcoded in many rock packages to  default_pkg_config_search_suffixes. This change could be backed out again once all rock packages install into the system mandated suffixes. Also note that this is currently not needed on ubuntu since they still have /lib/pkgconfig hardcoded in pkg-config for their own pre-multiarch packages.