### PR TITLE
fix: line wrapping in progress display

### DIFF
--- a/lib/autobuild/progress_display.rb
+++ b/lib/autobuild/progress_display.rb
@@ -277,7 +277,7 @@ module Autobuild
                 until messages.empty?
                     msg = messages.shift.strip
                     margin = messages.empty? ? 1 : 2
-                    if lines.last.size + margin + msg.size > width
+                    if lines.last.size + margin + msg.size + 1 > width
                         lines.last << ","
                         lines << +""
                         lines.last << indent << indent << msg


### PR DESCRIPTION
The comma that gets appended to the progress messages
has to be accounted for when determening whether the line
should be wrapped or not.

Without patch:
![without_patch](https://user-images.githubusercontent.com/17409636/183265100-cf505e11-8a1d-47b7-9559-0fbc8cd8ef27.gif)


With the patch:
![with_patch](https://user-images.githubusercontent.com/17409636/183264818-107af4ac-926c-4266-bf38-29124c7f2e78.gif)

