### PR TITLE
Consistently use importdir as patch location

### DIFF
--- a/lib/autobuild/importer.rb
+++ b/lib/autobuild/importer.rb
@@ -540,10 +540,10 @@ module Autobuild
             File.readlines(patches_file).map do |line|
                 line = line.rstrip
                 if line =~ /^(.*)\s+(\d+)$/
-                    path = File.expand_path($1, package.srcdir)
+                    path = File.expand_path($1, package.importdir)
                     level = Integer($2)
                 else
-                    path = File.expand_path(line, package.srcdir)
+                    path = File.expand_path(line, package.importdir)
                     level = 0
                 end
                 [path, level, File.read(path)]
@@ -618,7 +618,7 @@ module Autobuild
             File.open(patchlist(package), 'w') do |f|
                 patch_state = cur_patches.map do |path, level|
                     path = Pathname.new(path).
-                        relative_path_from(Pathname.new(package.srcdir)).to_s
+                        relative_path_from(Pathname.new(package.importdir)).to_s
                     "#{path} #{level}"
                 end
                 f.write(patch_state.join("\n"))


### PR DESCRIPTION
We are using autoproj/autobuild to organize our ROS2 workspaces (for aup/osdeps).
Often ROS2 repos contain several packages instead of only one.

We (hackily) archieve the compatibility of these packages by setting a common importdir and defining `interactive: true `
in the source.yml to prevent parallel checkouts into the same folder.

But patching these packages fails because autobuild places the patches in the importdir, but then searches for them in the srcdir, which is not the same in our case.

This PR fixes the behavior by consistently using the importdir as patch location.

For more information about the multi-package repo handling we are using:

The complete package_set (work in progress) :https://github.com/dfki-ric/ros2-package_set
Package definition: https://github.com/dfki-ric/ros2-package_set/blob/master/ros-2.autobuild#L21-L22
Source definition: https://github.com/dfki-ric/ros2-package_set/blob/master/source.yml#L85-L87
Package Type Definition: https://github.com/dfki-ric/ros2-package_set/blob/master/lib/colcon_package.rb

FYI: There is also support for the import of rock packages and generic libs into the colcon workspace to be directly build with colcon (set up pkg-config, generate package.xml, setting cmake_args from the autobuild file)



