### PR TITLE
fix: make sure Environment#[] returns an inherited value after the inherit call

### DIFF
--- a/lib/autobuild/environment.rb
+++ b/lib/autobuild/environment.rb
@@ -256,6 +256,7 @@ module Autobuild
             if flag
                 @inherited_variables |= names
                 names.each do |env_name|
+                    @environment[env_name] ||= []
                     init_from_env(env_name)
                 end
             else

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -12,6 +12,11 @@ module Autobuild
                 @env = Environment.new
                 @env.inherit 'AUTOBUILD_TEST'
             end
+
+            it "is available right after the inherit call" do
+                assert_equal "val1:val0", @env["AUTOBUILD_TEST"]
+            end
+
             describe "push_path" do
                 it "does not re-read the inherited environment" do
                 end


### PR DESCRIPTION
It would appear as set only after some values were added to it.