### PR TITLE
Added vcs-type subpackage.

### DIFF
--- a/lib/autobuild.rb
+++ b/lib/autobuild.rb
@@ -64,6 +64,7 @@ require 'autobuild/import/hg'
 require 'autobuild/import/svn'
 require 'autobuild/import/archive'
 require 'autobuild/import/tar'
+require 'autobuild/import/subpackage'
 
 require 'autobuild/package'
 require 'autobuild/configurable'

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -6,25 +6,25 @@ module Autobuild
             parent_name = options[:parent]
             unless parent_name
               raise PackageException,
-                "Subpackage must provide a parent package."
+                    "Subpackage must provide a parent package."
             end
 
             @parent = Autoproj.workspace.manifest.package_definition_by_name(parent_name)
             unless @parent
               raise PackageException,
-                "Parent package #{parent_name} does not exist."
+                    "Parent package #{parent_name} does not exist."
             end
 
             super(options.merge(repository_id: source))
         end
 
         # Does nothing, parent will do update
-        def update(_package, options = Hash.new)
-            false 
+        def update(_package, _options = Hash.new)
+            false
         end
 
         # Does nothing, parent will be checked out
-        def checkout(package, options = Hash.new)
+        def checkout(package, _options = Hash.new)
             package.depends_on(@parent.autobuild)
         end
 
@@ -38,4 +38,3 @@ module Autobuild
         Subpackage.new(source, options)
     end
 end
-

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -1,0 +1,33 @@
+module Autobuild
+    class Subpackage < Importer
+        def initialize(source, options = {})
+            @source = source
+            parent_name = options[:parent]
+            if !parent_name
+              raise "Subpackage must provide a parent package."
+            end
+
+            @parent = Autoproj.workspace.manifest.package_definition_by_name(parent_name)
+            if !@parent
+              raise "Parent package #{parent_name} does not exist."
+            end
+
+            if !@parent.autobuild.importer
+              raise "Parent package #{parent_name} has no importer."
+            end
+            super(options.merge(repository_id: source))
+        end
+
+        def update(package, options = Hash.new) # :nodoc:
+            @parent.autobuild.importer.update(@parent)
+        end
+
+        def checkout(package, _options = Hash.new) # :nodoc:
+            @parent.autobuild.importer.checkout(@parent.autobuild)
+        end
+    end
+
+    def self.subpackage(source, options = {})
+        Subpackage.new(source, options)
+    end
+end

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -16,15 +16,18 @@ module Autobuild
             super(options.merge(repository_id: source))
         end
 
-        def update(_package, options = Hash.new) # Does nothing, parent will do update
+        # Does nothing, parent will do update
+        def update(_package, options = Hash.new)
             false 
         end
 
-        def checkout(package, options = Hash.new) # Does nothing, parent will be checked out
+        # Does nothing, parent will be checked out
+        def checkout(package, options = Hash.new)
             package.depends_on(@parent.autobuild)
         end
-        
-        def snapshot(*) # Does nothing, parent will do snapshot
+
+        # Does nothing, parent will do snapshot
+        def snapshot(*)
             true
         end
     end
@@ -33,3 +36,4 @@ module Autobuild
         Subpackage.new(source, options)
     end
 end
+

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -2,11 +2,20 @@ module Autobuild
     class Subpackage < Importer
         def initialize(source, options = {})
             @source = source
+
             parent_name = options[:parent]
-            raise "Subpackage must provide a parent package." unless parent_name
+            unless parent_name
+              raise "Subpackage must provide a parent package."
+            end
+
             @parent = Autoproj.workspace.manifest.package_definition_by_name(parent_name)
-            raise "Parent package #{parent_name} does not exist." unless @parent
-            raise "Parent package #{parent_name} has no importer." unless @parent.autobuild.importer
+            unless @parent
+              raise "Parent package #{parent_name} does not exist."
+            end
+
+            unless @parent.autobuild.importer
+              raise "Parent package #{parent_name} has no importer."
+            end
 
             super(options.merge(repository_id: source))
         end

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -5,12 +5,14 @@ module Autobuild
 
             parent_name = options[:parent]
             unless parent_name
-              raise "Subpackage must provide a parent package."
+              raise PackageException,
+                "Subpackage must provide a parent package."
             end
 
             @parent = Autoproj.workspace.manifest.package_definition_by_name(parent_name)
             unless @parent
-              raise "Parent package #{parent_name} does not exist."
+              raise PackageException,
+                "Parent package #{parent_name} does not exist."
             end
 
             super(options.merge(repository_id: source))

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -3,27 +3,20 @@ module Autobuild
         def initialize(source, options = {})
             @source = source
             parent_name = options[:parent]
-            if !parent_name
-              raise "Subpackage must provide a parent package."
-            end
-
+            raise "Subpackage must provide a parent package." unless parent_name
             @parent = Autoproj.workspace.manifest.package_definition_by_name(parent_name)
-            if !@parent
-              raise "Parent package #{parent_name} does not exist."
-            end
+            raise "Parent package #{parent_name} does not exist." unless @parent
+            raise "Parent package #{parent_name} has no importer." unless @parent.autobuild.importer
 
-            if !@parent.autobuild.importer
-              raise "Parent package #{parent_name} has no importer."
-            end
             super(options.merge(repository_id: source))
         end
 
-        def update(package, options = Hash.new) # :nodoc:
-            @parent.autobuild.importer.update(@parent)
+        def update(_package, options = Hash.new) # :nodoc:
+            @parent.autobuild.importer.update(@parent, options)
         end
 
-        def checkout(package, _options = Hash.new) # :nodoc:
-            @parent.autobuild.importer.checkout(@parent.autobuild)
+        def checkout(_package, options = Hash.new) # :nodoc:
+            @parent.autobuild.importer.checkout(@parent.autobuild, options)
         end
     end
 

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -16,12 +16,16 @@ module Autobuild
             super(options.merge(repository_id: source))
         end
 
-        def update(_package, options = Hash.new) # :nodoc:
+        def update(_package, options = Hash.new) # Does nothing, parent will do update
             false 
         end
 
-        def checkout(package, options = Hash.new) # :nodoc:
+        def checkout(package, options = Hash.new) # Does nothing, parent will be checked out
             package.depends_on(@parent.autobuild)
+        end
+        
+        def snapshot(*) # Does nothing, parent will do snapshot
+            true
         end
     end
 

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -21,7 +21,7 @@ module Autobuild
         end
 
         def update(_package, options = Hash.new) # :nodoc:
-            @parent.autobuild.importer.update(@parent, options)
+            @parent.autobuild.importer.update(@parent.autobuild, options)
         end
 
         def checkout(_package, options = Hash.new) # :nodoc:

--- a/lib/autobuild/import/subpackage.rb
+++ b/lib/autobuild/import/subpackage.rb
@@ -13,19 +13,15 @@ module Autobuild
               raise "Parent package #{parent_name} does not exist."
             end
 
-            unless @parent.autobuild.importer
-              raise "Parent package #{parent_name} has no importer."
-            end
-
             super(options.merge(repository_id: source))
         end
 
         def update(_package, options = Hash.new) # :nodoc:
-            @parent.autobuild.importer.update(@parent.autobuild, options)
+            false 
         end
 
-        def checkout(_package, options = Hash.new) # :nodoc:
-            @parent.autobuild.importer.checkout(@parent.autobuild, options)
+        def checkout(package, options = Hash.new) # :nodoc:
+            package.depends_on(@parent.autobuild)
         end
     end
 


### PR DESCRIPTION
This allows to define a package that is located in a sub-directory of another package. Use cases are common multi-packages commonly used in the ROS world (one repository with many packages inside), but also cases like cmake-packages that come with their ruby/python bindings in ruby/python subpackages.

@planthaber @chhtz @doudou 